### PR TITLE
Fix #5: locale-gen: unknown -d option

### DIFF
--- a/build_tiny_linux.sh
+++ b/build_tiny_linux.sh
@@ -1019,7 +1019,7 @@ build_newroot()
     # Prepare locales
     [[ -d "$NEWROOT"/usr/lib/locale ]] && die "Unexpected directory: $NEWROOT/usr/lib/locale"
     [[ -d "$NEWROOT"/usr/lib64/locale ]] && die "Unexpected directory: $NEWROOT/usr/lib64/locale"
-    locale-gen -c "$BUILDSCRIPTS/locale.gen" -d "$NEWROOT"
+    locale-gen -c "$BUILDSCRIPTS/locale.gen" --prefix "$NEWROOT"
     if [[ -d "$NEWROOT"/usr/lib && -d "$NEWROOT"/usr/lib64 && -d "$NEWROOT"/usr/lib/locale && ! -d "$NEWROOT"/usr/lib64/locale ]]; then
         mv "$NEWROOT"/usr/lib/locale "$NEWROOT"/usr/lib64/locale
     fi

--- a/build_tiny_linux.sh
+++ b/build_tiny_linux.sh
@@ -1664,7 +1664,7 @@ compress_final_package()
 
 download_packages           # Download stage3/portage.
 unpack_packages             # Unpack stage3/portage into buildroot.
-copy_scripts                # Copy build_tiny_linux.sh and optionally other scripts into buildroot/buidscripts.
+copy_scripts                # Copy build_tiny_linux.sh and optionally other scripts into buildroot/buildscripts.
 run_in_chroot               # chroot into buildroot (Gentoo image).
 source /etc/profile         # Update environment of the root user.
 check_env                   # Sanity check.


### PR DESCRIPTION
Hi @cdragan.

I just came across this issue and found that there's a `--prefix` option provided by latest `locale-gen`. Thus, I created this PR to fix it.

Besides, I noticed that there's a typo in the script, so I fixed it too.